### PR TITLE
Made this work with runserver:

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,16 @@ module.exports = function (grunt) {
                 // only if your 'manager.py' is on another path
                 manage_path: './path/to/manage/'
             },
+            serve: {
+		options: {
+                    command: 'runserver',
+                    args: [],
+                    background: true, // also accepts string/regexp
+                    unBuffered: true // set python env to PYTHONUNBUFFERED=1 so STDOUT doesnt get buffered and grunt can read it
+                    // NOTE: background setting also sets unBuffered to true by default
+		    
+		}
+            },
             test: {
                 options: {
                     command: 'test',
@@ -57,7 +67,7 @@ module.exports = function (grunt) {
             'compile': {
                 options: {
                     command: 'compilemessages',
-                    verbose: true
+                    verbose: true // or 'errors' for STDERROR messages only
                 }
             }
         }

--- a/tasks/cmd.js
+++ b/tasks/cmd.js
@@ -35,12 +35,12 @@ function executeCmd(command, args, options, background) {
 
                 process.on('exit', function() {
                     process.kill( -cProcess.pid, 'SIGKILL' );
-                })
+                });
 
                 process.once('SIGINT', function() {
                     process.kill( -cProcess.pid, 'SIGKILL' );
-                    process.kill(-process.pid, 'SIGINT')
-                })
+                    process.kill(-process.pid, 'SIGINT');
+                });
                 deferred.resolve([stdout, stderr]);
             }
         }

--- a/tasks/cmd.js
+++ b/tasks/cmd.js
@@ -7,33 +7,58 @@ var PThrottler = require('p-throttler');
 
 var throttler = new PThrottler(5);
 
-function executeCmd(command, args, options) {
-    var process;
+function executeCmd(command, args, options, background) {
+    var cProcess;
     var stderr = '';
     var stdout = '';
     var deferred = Q.defer();
 
+
+    if(background){
+        var bgExp = background === true ? 'Quit the server with CONTROL-C' : background;
+        setTimeout(function(){
+    		deferred.notify({status: 'Listening for "' + bgExp.toString() + '" on STDOUT to complete task' });
+    	},0);
+        options.detached = true;
+    }
+
     // Buffer output, reporting progress
-    process = cp.spawn(command, args, options);
-    process.stdout.on('data', function (data) {
+    cProcess = cp.spawn(command, args, options);
+
+    cProcess.stdout.on('data', function (data) {
         data = data.toString();
-        deferred.notify(data);
+        deferred.notify({msg:data});
         stdout += data;
+        if(background){
+
+            if(data.match(bgExp)){
+
+                process.on('exit', function() {
+                    process.kill( -cProcess.pid, 'SIGKILL' );
+                })
+
+                process.once('SIGINT', function() {
+                    process.kill( -cProcess.pid, 'SIGKILL' );
+                    process.kill(-process.pid, 'SIGINT')
+                })
+                deferred.resolve([stdout, stderr]);
+            }
+        }
     });
-    process.stderr.on('data', function (data) {
+    cProcess.stderr.on('data', function (data) {
         data = data.toString();
-        deferred.notify(data);
+        deferred.notify({error:data});
         stderr += data;
     });
 
     // If there is an error spawning the command, reject the promise
-    process.on('error', function (error) {
+    cProcess.on('error', function (error) {
         return deferred.reject(error);
     });
 
     // Listen to the close event instead of exit
     // They are similar but close ensures that streams are flushed
-    process.on('close', function (code) {
+    cProcess.on('close', function (code) {
         var fullCommand;
         var error;
 
@@ -61,8 +86,8 @@ function executeCmd(command, args, options) {
     return deferred.promise;
 }
 
-function cmd(command, args, options) {
-    return throttler.enqueue(executeCmd.bind(null, command, args, options));
+function cmd(command, args, options, background) {
+    return throttler.enqueue(executeCmd.bind(null, command, args, options, background));
 }
 
 module.exports = cmd;

--- a/tasks/tasks.js
+++ b/tasks/tasks.js
@@ -22,7 +22,7 @@ module.exports = function(grunt){
             var env = Object.create( process.env );
             env.PYTHONUNBUFFERED = 1;
             opts.env = env;
-        };
+        }
 
 
         cmd('python', args , opts, options.background)
@@ -31,7 +31,7 @@ module.exports = function(grunt){
                     var msg = data.msg.toString();
                     grunt.log.write(msg);
                 }
-                if (options.verbose == 'errors' && data.error){
+                if (options.verbose === 'errors' && data.error){
                     var error = data.error.toString();
                     grunt.log.error(error);
                 }
@@ -64,7 +64,7 @@ module.exports = function(grunt){
             var env = Object.create( process.env );
             env.PYTHONUNBUFFERED = 1;
             opts.env = env;
-        };
+        }
 
         cmd('django-admin.py', args , opts, options.background)
             .progress(function(data){
@@ -72,7 +72,7 @@ module.exports = function(grunt){
                     var msg = data.msg.toString();
                     grunt.log.write(msg);
                 }
-                if (options.verbose == 'errors' && data.error){
+                if (options.verbose === 'errors' && data.error){
                     var error = data.error.toString();
                     grunt.log.error(error);
                 }


### PR DESCRIPTION
I wanted to use this package with django's default devserver for e2e testing purposes.
When I tried adding an option to keep the server running in the background while doing tasks, I ran into some issues with python subprocesses and STDOUT buffering, but I believe I've got those sorted. 
- listens for specific STDOUT message (by regex or string, 'Quit the server with CONTROL-C' by default)
- triggers task done but keeps server running in background
- kills server (+ subprocesses) when grunt is done
- also kills server on SIGINT
- added an option to allow verbose only for STDERROR, since runserver is prone to spew all the http requests.
